### PR TITLE
Suppress FD's "press any key" prompt

### DIFF
--- a/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
@@ -148,7 +148,7 @@ namespace FrankenDrift.Runner
                     if (currentToken.StartsWith("img"))  // graphics.
                     {
                         var imgPath = new Regex("src ?= ?\"(.+)\"").Match(currentToken);
-                        if (imgPath.Success && SettingsManager.Instance.Settings.EnableGraphics)
+                        if (imgPath.Success && SettingsManager.Settings.EnableGraphics)
                             _main.Graphics.DisplayImage(imgPath.Groups[1].Value);
                         continue;
                     }

--- a/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
@@ -125,7 +125,8 @@ namespace FrankenDrift.Runner
                         case "waitkey":
                             _pendingText = src[consumed..];
                             IsWaiting = true;
-                            AppendWithFont("\n(Press any key to continue)");
+                            if (SettingsManager.Settings.EnablePressAnyKey)
+                                AppendWithFont("\n(Press any key to continue)");
                             return;
                         case "/c":
                         case "/font":

--- a/FrankenDrift.Runner/FrankenDrift.Runner/MainForm.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/MainForm.cs
@@ -397,7 +397,7 @@ namespace FrankenDrift.Runner
 
         public void ShowCoverArt(Image img)
         {
-            if (SettingsManager.Instance.Settings.EnableGraphics)
+            if (SettingsManager.Settings.EnableGraphics)
                 Graphics.DisplayImage(img);
         }
 
@@ -440,7 +440,7 @@ namespace FrankenDrift.Runner
         // any text for the first time.
         public void SetBackgroundColour()
         {
-            if (SettingsManager.Instance.Settings.EnableDevColors)
+            if (SettingsManager.Settings.EnableDevColors)
             {
                 var adventure = Adrift.SharedModule.Adventure;
                 if (!adventure.DeveloperDefaultBackgroundColour.IsEmpty)

--- a/FrankenDrift.Runner/FrankenDrift.Runner/SettingsDialog.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/SettingsDialog.cs
@@ -8,6 +8,7 @@ namespace FrankenDrift.Runner
     {
         private CheckBox _graphics;
         private CheckBox _devColors;
+        private CheckBox _anyKeyPrompt;
 
         private Button _okButton;
         private Button _cancelButton;
@@ -28,6 +29,11 @@ namespace FrankenDrift.Runner
                 Checked = SettingsManager.Settings.EnableDevColors,
                 ToolTip = "Whether or not FrankenDrift should honor the developer's choice of color. (A restart is needed for this setting to take full effect.)"
             };
+            _anyKeyPrompt = new CheckBox {
+                Text = "Enable \"Press any key\" prompts",
+                Checked = SettingsManager.Settings.EnablePressAnyKey,
+                ToolTip = "Whether to show \"(Press any key to continue)\" when the game waits for a key press."
+            };
 
             Title = "Settings - FrankenDrift";
             _okButton = new Button {Text = "OK"};
@@ -37,6 +43,7 @@ namespace FrankenDrift.Runner
             Content = new StackLayout(
                 new StackLayoutItem(_graphics),
                 new StackLayoutItem(_devColors),
+                new StackLayoutItem(_anyKeyPrompt),
                 new StackLayoutItem(_okButton),
                 new StackLayoutItem(_cancelButton));
             DefaultButton = _okButton;
@@ -47,6 +54,7 @@ namespace FrankenDrift.Runner
         {
             SettingsManager.Settings.EnableGraphics = _graphics.Checked ?? false;
             SettingsManager.Settings.EnableDevColors = _devColors.Checked ?? false;
+            SettingsManager.Settings.EnablePressAnyKey = _anyKeyPrompt.Checked ?? false;
             SettingsManager.Instance.Save();
             Close();
         }

--- a/FrankenDrift.Runner/FrankenDrift.Runner/SettingsDialog.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/SettingsDialog.cs
@@ -21,11 +21,11 @@ namespace FrankenDrift.Runner
         {
             _graphics = new CheckBox {
                 Text = "Enable graphics",
-                Checked = SettingsManager.Instance.Settings.EnableGraphics
+                Checked = SettingsManager.Settings.EnableGraphics
             };
             _devColors = new CheckBox {
                 Text = "Enable author-chosen colors",
-                Checked = SettingsManager.Instance.Settings.EnableDevColors,
+                Checked = SettingsManager.Settings.EnableDevColors,
                 ToolTip = "Whether or not FrankenDrift should honor the developer's choice of color. (A restart is needed for this setting to take full effect.)"
             };
 
@@ -34,7 +34,8 @@ namespace FrankenDrift.Runner
             _okButton.Click += OkButtonOnClick;
             _cancelButton = new Button {Text = "Cancel"};
             _cancelButton.Click += (sender, args) => Close(); 
-            Content = new StackLayout(new StackLayoutItem(_graphics),
+            Content = new StackLayout(
+                new StackLayoutItem(_graphics),
                 new StackLayoutItem(_devColors),
                 new StackLayoutItem(_okButton),
                 new StackLayoutItem(_cancelButton));
@@ -44,8 +45,8 @@ namespace FrankenDrift.Runner
 
         private void OkButtonOnClick(object? sender, EventArgs e)
         {
-            SettingsManager.Instance.Settings.EnableGraphics = _graphics.Checked ?? false;
-            SettingsManager.Instance.Settings.EnableDevColors = _devColors.Checked ?? false;
+            SettingsManager.Settings.EnableGraphics = _graphics.Checked ?? false;
+            SettingsManager.Settings.EnableDevColors = _devColors.Checked ?? false;
             SettingsManager.Instance.Save();
             Close();
         }

--- a/FrankenDrift.Runner/FrankenDrift.Runner/SettingsManager.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/SettingsManager.cs
@@ -26,11 +26,11 @@ namespace FrankenDrift.Runner
             if (File.Exists(_settingsFile))
             {
                 var settingsText = File.ReadAllText(_settingsFile);
-                Settings = JsonSerializer.Deserialize<Settings>(settingsText);
+                _settings = JsonSerializer.Deserialize<Settings>(settingsText);
             }
             else
             {
-                Settings = new Settings {
+                _settings = new Settings {
                     EnableGraphics = true,
                     EnableDevColors = true
                 };
@@ -38,13 +38,14 @@ namespace FrankenDrift.Runner
         }
         private static readonly Lazy<SettingsManager> lazySmgr = new(() => new SettingsManager());
         public static SettingsManager Instance => lazySmgr.Value;
+        public static Settings Settings => lazySmgr.Value._settings;
 
-        public Settings Settings { get; }
+        private Settings _settings { get; }
 
         public void Save()
         {
             var options = new JsonSerializerOptions {WriteIndented = true};
-            string jsonSettings = JsonSerializer.Serialize(Settings, options);
+            string jsonSettings = JsonSerializer.Serialize(_settings, options);
             Directory.CreateDirectory(_settingsPath);
             File.WriteAllText(_settingsFile, jsonSettings);
         }

--- a/FrankenDrift.Runner/FrankenDrift.Runner/SettingsManager.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/SettingsManager.cs
@@ -32,7 +32,8 @@ namespace FrankenDrift.Runner
             {
                 _settings = new Settings {
                     EnableGraphics = true,
-                    EnableDevColors = true
+                    EnableDevColors = true,
+                    EnablePressAnyKey = false
                 };
             }
         }
@@ -55,5 +56,6 @@ namespace FrankenDrift.Runner
     {
         public bool EnableGraphics { get; set; }
         public bool EnableDevColors { get; set; }
+        public bool EnablePressAnyKey { get; set; }
     }
 }


### PR DESCRIPTION
The Adrift Runner does not display a "Press any key to continue"-style prompt for the `<waitkey>` tag, so most authors supply their own. This makes FrankenDrift's prompt redundant. Add an option to disable it (the new default).