### PR TITLE
Fix prompt on non-Windows systems

### DIFF
--- a/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
@@ -88,7 +88,7 @@ namespace FrankenDrift.Runner
             }
             ReadOnly = false;
             if (!_wingdingsAvailable)
-                src = src.Replace("<font face=\"Wingdings\" size=14>Ø</font>", "<font size=+2>> </font>");
+                src = src.Replace("<font face=\"Wingdings\" size=14>Ã˜</font>", "<font size=+1>></font>");
             var consumed = 0;
             var inToken = false;
             var current = new StringBuilder();

--- a/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Eto.Forms;
 using Eto.Drawing;
 using System.Text;
@@ -25,6 +26,7 @@ namespace FrankenDrift.Runner
             Append(" ");
             
             _fonts.Push(new Tuple<Font, Color>(_defaultFont, _defaultColor));
+            _wingdingsAvailable = Fonts.AvailableFontFamilies.Any(f => f.Name == "Wingdings");
         }
 
         // Needs to be a separate overload rather than just introducing an optional
@@ -59,6 +61,7 @@ namespace FrankenDrift.Runner
         internal Font _defaultFont;
         private readonly Stack<Tuple<Font, Color>> _fonts = new();
         private readonly MainForm _main;
+        private readonly bool _wingdingsAvailable;
 
         private bool _bold = false;
         private bool _italic = false;
@@ -82,6 +85,8 @@ namespace FrankenDrift.Runner
                 return;
             }
             ReadOnly = false;
+            if (!_wingdingsAvailable)
+                src.Replace("<font face=\"Wingdings\" size=14>Ø</font>", "<font size=+2>> </font>");
             var consumed = 0;
             var inToken = false;
             var current = new StringBuilder();

--- a/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/AdriftOutput.cs
@@ -18,6 +18,8 @@ namespace FrankenDrift.Runner
             SelectionForeground = _defaultColor;
             if (!string.IsNullOrEmpty(SettingsManager.Settings.DefaultFontName))
                 _defaultFont = SelectionFont.WithFontFace(SettingsManager.Settings.DefaultFontName);
+            else
+                _defaultFont = SelectionFont;
             if (SettingsManager.Settings.EnableDevFont)
                 _defaultFont = _defaultFont.WithSize(SelectionFont.Size+SettingsManager.Settings.AlterFontSize);
             else
@@ -86,7 +88,7 @@ namespace FrankenDrift.Runner
             }
             ReadOnly = false;
             if (!_wingdingsAvailable)
-                src.Replace("<font face=\"Wingdings\" size=14>Ø</font>", "<font size=+2>> </font>");
+                src = src.Replace("<font face=\"Wingdings\" size=14>Ø</font>", "<font size=+2>> </font>");
             var consumed = 0;
             var inToken = false;
             var current = new StringBuilder();

--- a/FrankenDrift.Runner/FrankenDrift.Runner/MainForm.cs
+++ b/FrankenDrift.Runner/FrankenDrift.Runner/MainForm.cs
@@ -86,6 +86,7 @@ namespace FrankenDrift.Runner
         {
             Title = "FrankenDrift";
             MinimumSize = new Size(400, 400);
+            Size = new Size(600, 750);
             Padding = 10;
 
             output = new AdriftOutput(this);


### PR DESCRIPTION
Fix the display of the prompt symbol when the Wingdings font isn't available. Closes #15 