### PR TITLE
Glk opaque types

### DIFF
--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
@@ -11,9 +11,9 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern BlorbError giblorb_set_resource_map(IntPtr fileStream);
         [DllImport("libgarglk")]
-        internal static extern void glk_cancel_hyperlink_event(IntPtr winId);
+        internal static extern void glk_cancel_hyperlink_event(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern void glk_cancel_line_event(IntPtr winId, ref Event ev);
+        internal static extern void glk_cancel_line_event(WindowHandle winId, ref Event ev);
         [DllImport("libgarglk")]
         internal static extern void glk_exit();
         [DllImport("libgarglk")]
@@ -25,7 +25,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_fileref_destroy(IntPtr fref);
         [DllImport("libgarglk")]
-        internal static extern uint glk_image_draw(IntPtr winid, uint imageId, int val1, int val2);
+        internal static extern uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2);
         [DllImport("libgarglk")]
         internal static extern uint glk_image_get_info(uint imageId, ref uint width, ref uint height);
         [DllImport("libgarglk")]
@@ -35,13 +35,13 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_put_buffer_uni([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] s, uint len);
         [DllImport("libgarglk")]
-        internal static extern void glk_request_char_event(IntPtr winId);
+        internal static extern void glk_request_char_event(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern void glk_request_hyperlink_event(IntPtr winId);
+        internal static extern void glk_request_hyperlink_event(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern unsafe void glk_request_line_event(IntPtr win, byte* buf, uint maxlen, uint initlen);
+        internal static extern unsafe void glk_request_line_event(WindowHandle win, byte* buf, uint maxlen, uint initlen);
         [DllImport("libgarglk")]
-        internal static extern unsafe void glk_request_line_event_uni(IntPtr win, uint* buf, uint maxlen, uint initlen);
+        internal static extern unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen);
         [DllImport("libgarglk")]
         internal static extern IntPtr glk_schannel_create(uint rock);
         [DllImport("libgarglk")]
@@ -65,7 +65,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_set_style(Style s);
         [DllImport("libgarglk")]
-        internal static extern void glk_set_window(IntPtr winId);
+        internal static extern void glk_set_window(WindowHandle winId);
         [DllImport("libgarglk")]
         internal static extern IntPtr glk_stream_open_file(IntPtr fileref, Glk.FileMode fmode, uint rock);
         [DllImport("libgarglk")]
@@ -75,23 +75,23 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val);
         [DllImport("libgarglk")]
-        internal static extern uint glk_style_measure(IntPtr winid, Style styl, StyleHint hint, ref uint result);
+        internal static extern uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result);
         [DllImport("libgarglk")]
         internal static extern void glk_tick();
         [DllImport("libgarglk")]
-        internal static extern void glk_window_clear(IntPtr winId);
+        internal static extern void glk_window_clear(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern void glk_window_close(IntPtr winId, IntPtr streamResult);
+        internal static extern void glk_window_close(WindowHandle winId, IntPtr streamResult);
         [DllImport("libgarglk")]
-        internal static extern void glk_window_flow_break(IntPtr winId);
+        internal static extern void glk_window_flow_break(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern void glk_window_get_size(IntPtr winId, out uint width, out uint height);
+        internal static extern void glk_window_get_size(WindowHandle winId, out uint width, out uint height);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_window_get_stream(IntPtr winId);
+        internal static extern IntPtr glk_window_get_stream(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern void glk_window_move_cursor(IntPtr winId, uint xpos, uint ypos);
+        internal static extern void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_window_open(IntPtr split, WinMethod method, uint size, WinType wintype, uint rock);
+        internal static extern WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock);
         [DllImport("libgarglk")]
         internal static extern void garglk_set_zcolors(uint fg, uint bg);
         [DllImport("libgarglk")]
@@ -113,22 +113,22 @@ namespace FrankenDrift.GlkRunner.Gargoyle
     class GarGlk: IGlk
     {
         public BlorbError giblorb_set_resource_map(IntPtr fileStream) => Garglk_Pinvoke.giblorb_set_resource_map(fileStream);
-        public void glk_cancel_hyperlink_event(IntPtr winId) => Garglk_Pinvoke.glk_cancel_hyperlink_event(winId);
-        public void glk_cancel_line_event(IntPtr winId, ref Event ev) => Garglk_Pinvoke.glk_cancel_line_event(winId, ref ev);
+        public void glk_cancel_hyperlink_event(WindowHandle winId) => Garglk_Pinvoke.glk_cancel_hyperlink_event(winId);
+        public void glk_cancel_line_event(WindowHandle winId, ref Event ev) => Garglk_Pinvoke.glk_cancel_line_event(winId, ref ev);
         public void glk_exit() => Garglk_Pinvoke.glk_exit();
         public IntPtr glk_fileref_create_by_name(FileUsage usage, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_fileref_create_by_name(usage, fmode, rock);
         public IntPtr glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_fileref_create_by_prompt(usage, fmode, rock);
         public IntPtr glk_fileref_create_temp(FileUsage usage, uint rock) => Garglk_Pinvoke.glk_fileref_create_temp(usage, rock);
         public void glk_fileref_destroy(IntPtr fref) => Garglk_Pinvoke.glk_fileref_destroy(fref);
-        public uint glk_image_draw(IntPtr winid, uint imageId, int val1, int val2) => Garglk_Pinvoke.glk_image_draw(winid, imageId, val1, val2);
+        public uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2) => Garglk_Pinvoke.glk_image_draw(winid, imageId, val1, val2);
         public uint glk_image_get_info(uint imageId, ref uint width, ref uint height) => Garglk_Pinvoke.glk_image_get_info(imageId, ref width, ref height);
-        public void glk_put_buffer([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len) => Garglk_Pinvoke.glk_put_buffer(s, len);
-        public void glk_put_buffer_stream(IntPtr streamId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len) => Garglk_Pinvoke.glk_put_buffer_stream(streamId, s, len);
-        public void glk_put_buffer_uni([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] s, uint len) => Garglk_Pinvoke.glk_put_buffer_uni(s, len);
-        public void glk_request_char_event(IntPtr winId) => Garglk_Pinvoke.glk_request_char_event(winId);
-        public void glk_request_hyperlink_event(IntPtr winId) => Garglk_Pinvoke.glk_request_hyperlink_event(winId);
-        public unsafe void glk_request_line_event(IntPtr win, byte* buf, uint maxlen, uint initlen) => Garglk_Pinvoke.glk_request_line_event(win, buf, maxlen, initlen);
-        public unsafe void glk_request_line_event_uni(IntPtr win, uint* buf, uint maxlen, uint initlen) => Garglk_Pinvoke.glk_request_line_event_uni(win, buf, maxlen, initlen);
+        public void glk_put_buffer(byte[] s, uint len) => Garglk_Pinvoke.glk_put_buffer(s, len);
+        public void glk_put_buffer_stream(IntPtr streamId, byte[] s, uint len) => Garglk_Pinvoke.glk_put_buffer_stream(streamId, s, len);
+        public void glk_put_buffer_uni(uint[] s, uint len) => Garglk_Pinvoke.glk_put_buffer_uni(s, len);
+        public void glk_request_char_event(WindowHandle winId) => Garglk_Pinvoke.glk_request_char_event(winId);
+        public void glk_request_hyperlink_event(WindowHandle winId) => Garglk_Pinvoke.glk_request_hyperlink_event(winId);
+        public unsafe void glk_request_line_event(WindowHandle win, byte* buf, uint maxlen, uint initlen) => Garglk_Pinvoke.glk_request_line_event(win, buf, maxlen, initlen);
+        public unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen) => Garglk_Pinvoke.glk_request_line_event_uni(win, buf, maxlen, initlen);
         public IntPtr glk_schannel_create(uint rock) => Garglk_Pinvoke.glk_schannel_create(rock);
         public void glk_schannel_destroy(IntPtr chan) => Garglk_Pinvoke.glk_schannel_destroy(chan);
         public void glk_schannel_pause(IntPtr chan) => Garglk_Pinvoke.glk_schannel_pause(chan);
@@ -140,20 +140,20 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public void glk_select(ref Event ev) => Garglk_Pinvoke.glk_select(ref ev);
         public void glk_set_hyperlink(uint linkval) => Garglk_Pinvoke.glk_set_hyperlink(linkval);
         public void glk_set_style(Style s) => Garglk_Pinvoke.glk_set_style(s);
-        public void glk_set_window(IntPtr winId) => Garglk_Pinvoke.glk_set_window(winId);
+        public void glk_set_window(WindowHandle winId) => Garglk_Pinvoke.glk_set_window(winId);
         public IntPtr glk_stream_open_file(IntPtr fileref, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
         public IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Garglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
         public void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode) => Garglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
         public void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val) => Garglk_Pinvoke.glk_stylehint_set(wintype, styl, hint, val);
-        public uint glk_style_measure(IntPtr winid, Style styl, StyleHint hint, ref uint result) => Garglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);
+        public uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result) => Garglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);
         public void glk_tick() => Garglk_Pinvoke.glk_tick();
-        public void glk_window_clear(IntPtr winId) => Garglk_Pinvoke.glk_window_clear(winId);
-        public void glk_window_close(IntPtr winId, IntPtr streamResult) => Garglk_Pinvoke.glk_window_close(winId, streamResult);
-        public void glk_window_flow_break(IntPtr winId) => Garglk_Pinvoke.glk_window_flow_break(winId);
-        public void glk_window_get_size(IntPtr winId, out uint width, out uint height) => Garglk_Pinvoke.glk_window_get_size(winId, out width, out height);
-        public IntPtr glk_window_get_stream(IntPtr winId) => Garglk_Pinvoke.glk_window_get_stream(winId);
-        public void glk_window_move_cursor(IntPtr winId, uint xpos, uint ypos) => Garglk_Pinvoke.glk_window_move_cursor(winId, xpos, ypos);
-        public IntPtr glk_window_open(IntPtr split, WinMethod method, uint size, WinType wintype, uint rock) => Garglk_Pinvoke.glk_window_open(split, method, size, wintype, rock);
+        public void glk_window_clear(WindowHandle winId) => Garglk_Pinvoke.glk_window_clear(winId);
+        public void glk_window_close(WindowHandle winId, IntPtr streamResult) => Garglk_Pinvoke.glk_window_close(winId, streamResult);
+        public void glk_window_flow_break(WindowHandle winId) => Garglk_Pinvoke.glk_window_flow_break(winId);
+        public void glk_window_get_size(WindowHandle winId, out uint width, out uint height) => Garglk_Pinvoke.glk_window_get_size(winId, out width, out height);
+        public IntPtr glk_window_get_stream(WindowHandle winId) => Garglk_Pinvoke.glk_window_get_stream(winId);
+        public void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos) => Garglk_Pinvoke.glk_window_move_cursor(winId, xpos, ypos);
+        public WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock) => Garglk_Pinvoke.glk_window_open(split, method, size, wintype, rock);
         public void garglk_set_zcolors(uint fg, uint bg) => Garglk_Pinvoke.garglk_set_zcolors(fg, bg);
         public string? glkunix_fileref_get_name(IntPtr fileref) => Marshal.PtrToStringAnsi(Garglk_Pinvoke.glkunix_fileref_get_name(fileref));
 

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
@@ -43,21 +43,21 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_schannel_create(uint rock);
+        internal static extern SoundChannel glk_schannel_create(uint rock);
         [DllImport("libgarglk")]
-        internal static extern void glk_schannel_destroy(IntPtr chan);
+        internal static extern void glk_schannel_destroy(SoundChannel chan);
         [DllImport("libgarglk")]
-        internal static extern void glk_schannel_pause(IntPtr chan);
+        internal static extern void glk_schannel_pause(SoundChannel chan);
         [DllImport("libgarglk")]
-        internal static extern uint glk_schannel_play(IntPtr chan, uint sndId);
+        internal static extern uint glk_schannel_play(SoundChannel chan, uint sndId);
         [DllImport("libgarglk")]
-        internal static extern uint glk_schannel_play_ext(IntPtr chan, uint sndId, uint repeats, uint notify);
+        internal static extern uint glk_schannel_play_ext(SoundChannel chan, uint sndId, uint repeats, uint notify);
         [DllImport("libgarglk")]
-        internal static extern void glk_schannel_set_volume(IntPtr chan, uint vol);
+        internal static extern void glk_schannel_set_volume(SoundChannel chan, uint vol);
         [DllImport("libgarglk")]
-        internal static extern void glk_schannel_stop(IntPtr chan);
+        internal static extern void glk_schannel_stop(SoundChannel chan);
         [DllImport("libgarglk")]
-        internal static extern void glk_schannel_unpause(IntPtr chan);
+        internal static extern void glk_schannel_unpause(SoundChannel chan);
         [DllImport("libgarglk")]
         internal static extern void glk_select(ref Event ev);
         [DllImport("libgarglk")]
@@ -129,14 +129,14 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public void glk_request_hyperlink_event(WindowHandle winId) => Garglk_Pinvoke.glk_request_hyperlink_event(winId);
         public unsafe void glk_request_line_event(WindowHandle win, byte* buf, uint maxlen, uint initlen) => Garglk_Pinvoke.glk_request_line_event(win, buf, maxlen, initlen);
         public unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen) => Garglk_Pinvoke.glk_request_line_event_uni(win, buf, maxlen, initlen);
-        public IntPtr glk_schannel_create(uint rock) => Garglk_Pinvoke.glk_schannel_create(rock);
-        public void glk_schannel_destroy(IntPtr chan) => Garglk_Pinvoke.glk_schannel_destroy(chan);
-        public void glk_schannel_pause(IntPtr chan) => Garglk_Pinvoke.glk_schannel_pause(chan);
-        public uint glk_schannel_play(IntPtr chan, uint sndId) => Garglk_Pinvoke.glk_schannel_play(chan, sndId);
-        public uint glk_schannel_play_ext(IntPtr chan, uint sndId, uint repeats, uint notify) => Garglk_Pinvoke.glk_schannel_play_ext(chan, sndId, repeats, notify);
-        public void glk_schannel_set_volume(IntPtr chan, uint vol) => Garglk_Pinvoke.glk_schannel_set_volume(chan, vol);
-        public void glk_schannel_stop(IntPtr chan) => Garglk_Pinvoke.glk_schannel_stop(chan);
-        public void glk_schannel_unpause(IntPtr chan) => Garglk_Pinvoke.glk_schannel_unpause(chan);
+        public SoundChannel glk_schannel_create(uint rock) => Garglk_Pinvoke.glk_schannel_create(rock);
+        public void glk_schannel_destroy(SoundChannel chan) => Garglk_Pinvoke.glk_schannel_destroy(chan);
+        public void glk_schannel_pause(SoundChannel chan) => Garglk_Pinvoke.glk_schannel_pause(chan);
+        public uint glk_schannel_play(SoundChannel chan, uint sndId) => Garglk_Pinvoke.glk_schannel_play(chan, sndId);
+        public uint glk_schannel_play_ext(SoundChannel chan, uint sndId, uint repeats, uint notify) => Garglk_Pinvoke.glk_schannel_play_ext(chan, sndId, repeats, notify);
+        public void glk_schannel_set_volume(SoundChannel chan, uint vol) => Garglk_Pinvoke.glk_schannel_set_volume(chan, vol);
+        public void glk_schannel_stop(SoundChannel chan) => Garglk_Pinvoke.glk_schannel_stop(chan);
+        public void glk_schannel_unpause(SoundChannel chan) => Garglk_Pinvoke.glk_schannel_unpause(chan);
         public void glk_select(ref Event ev) => Garglk_Pinvoke.glk_select(ref ev);
         public void glk_set_hyperlink(uint linkval) => Garglk_Pinvoke.glk_set_hyperlink(linkval);
         public void glk_set_style(Style s) => Garglk_Pinvoke.glk_set_style(s);

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
@@ -69,7 +69,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern StreamHandle glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock);
         [DllImport("libgarglk")]
-        internal static extern StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock);
+        internal static unsafe extern StreamHandle glk_stream_open_memory(byte* buf, uint buflen, Glk.FileMode mode, uint rock);
         [DllImport("libgarglk")]
         internal static extern void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode);
         [DllImport("libgarglk")]
@@ -142,7 +142,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public void glk_set_style(Style s) => Garglk_Pinvoke.glk_set_style(s);
         public void glk_set_window(WindowHandle winId) => Garglk_Pinvoke.glk_set_window(winId);
         public StreamHandle glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
-        public StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Garglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
+        public unsafe StreamHandle glk_stream_open_memory(byte* buf, uint buflen, Glk.FileMode mode, uint rock) => Garglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
         public void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode) => Garglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
         public void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val) => Garglk_Pinvoke.glk_stylehint_set(wintype, styl, hint, val);
         public uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result) => Garglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
@@ -17,13 +17,13 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_exit();
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_fileref_create_by_name(FileUsage usage, Glk.FileMode fmode, uint rock);
+        internal static extern FileRefHandle glk_fileref_create_by_name(FileUsage usage, [MarshalAs(UnmanagedType.LPStr)] string name, Glk.FileMode fmode, uint rock);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock);
+        internal static extern FileRefHandle glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_fileref_create_temp(FileUsage usage, uint rock);
+        internal static extern FileRefHandle glk_fileref_create_temp(FileUsage usage, uint rock);
         [DllImport("libgarglk")]
-        internal static extern void glk_fileref_destroy(IntPtr fref);
+        internal static extern void glk_fileref_destroy(FileRefHandle fref);
         [DllImport("libgarglk")]
         internal static extern uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2);
         [DllImport("libgarglk")]
@@ -67,7 +67,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_set_window(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_stream_open_file(IntPtr fileref, Glk.FileMode fmode, uint rock);
+        internal static extern IntPtr glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock);
         [DllImport("libgarglk")]
         internal static extern IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock);
         [DllImport("libgarglk")]
@@ -95,7 +95,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void garglk_set_zcolors(uint fg, uint bg);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glkunix_fileref_get_name(IntPtr fileref);
+        internal static extern IntPtr glkunix_fileref_get_name(FileRefHandle fileref);
 
         // Garglk initialization functions.
         [DllImport("libgarglk")]
@@ -116,10 +116,10 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public void glk_cancel_hyperlink_event(WindowHandle winId) => Garglk_Pinvoke.glk_cancel_hyperlink_event(winId);
         public void glk_cancel_line_event(WindowHandle winId, ref Event ev) => Garglk_Pinvoke.glk_cancel_line_event(winId, ref ev);
         public void glk_exit() => Garglk_Pinvoke.glk_exit();
-        public IntPtr glk_fileref_create_by_name(FileUsage usage, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_fileref_create_by_name(usage, fmode, rock);
-        public IntPtr glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_fileref_create_by_prompt(usage, fmode, rock);
-        public IntPtr glk_fileref_create_temp(FileUsage usage, uint rock) => Garglk_Pinvoke.glk_fileref_create_temp(usage, rock);
-        public void glk_fileref_destroy(IntPtr fref) => Garglk_Pinvoke.glk_fileref_destroy(fref);
+        public FileRefHandle glk_fileref_create_by_name(FileUsage usage, string name, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_fileref_create_by_name(usage, name, fmode, rock);
+        public FileRefHandle glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_fileref_create_by_prompt(usage, fmode, rock);
+        public FileRefHandle glk_fileref_create_temp(FileUsage usage, uint rock) => Garglk_Pinvoke.glk_fileref_create_temp(usage, rock);
+        public void glk_fileref_destroy(FileRefHandle fref) => Garglk_Pinvoke.glk_fileref_destroy(fref);
         public uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2) => Garglk_Pinvoke.glk_image_draw(winid, imageId, val1, val2);
         public uint glk_image_get_info(uint imageId, ref uint width, ref uint height) => Garglk_Pinvoke.glk_image_get_info(imageId, ref width, ref height);
         public void glk_put_buffer(byte[] s, uint len) => Garglk_Pinvoke.glk_put_buffer(s, len);
@@ -141,7 +141,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public void glk_set_hyperlink(uint linkval) => Garglk_Pinvoke.glk_set_hyperlink(linkval);
         public void glk_set_style(Style s) => Garglk_Pinvoke.glk_set_style(s);
         public void glk_set_window(WindowHandle winId) => Garglk_Pinvoke.glk_set_window(winId);
-        public IntPtr glk_stream_open_file(IntPtr fileref, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
+        public IntPtr glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
         public IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Garglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
         public void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode) => Garglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
         public void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val) => Garglk_Pinvoke.glk_stylehint_set(wintype, styl, hint, val);
@@ -155,7 +155,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos) => Garglk_Pinvoke.glk_window_move_cursor(winId, xpos, ypos);
         public WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock) => Garglk_Pinvoke.glk_window_open(split, method, size, wintype, rock);
         public void garglk_set_zcolors(uint fg, uint bg) => Garglk_Pinvoke.garglk_set_zcolors(fg, bg);
-        public string? glkunix_fileref_get_name(IntPtr fileref) => Marshal.PtrToStringAnsi(Garglk_Pinvoke.glkunix_fileref_get_name(fileref));
+        public string? glkunix_fileref_get_name(FileRefHandle fileref) => Marshal.PtrToStringAnsi(Garglk_Pinvoke.glkunix_fileref_get_name(fileref));
 
         public void SetGameName(string game) => Garglk_Pinvoke.garglk_set_story_name(game);
 

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
@@ -9,7 +9,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
     {
         // Universal Glk functions.
         [DllImport("libgarglk")]
-        internal static extern BlorbError giblorb_set_resource_map(IntPtr fileStream);
+        internal static extern BlorbError giblorb_set_resource_map(StreamHandle fileStream);
         [DllImport("libgarglk")]
         internal static extern void glk_cancel_hyperlink_event(WindowHandle winId);
         [DllImport("libgarglk")]
@@ -31,7 +31,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_put_buffer([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len);
         [DllImport("libgarglk")]
-        internal static extern void glk_put_buffer_stream(IntPtr streamId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len);
+        internal static extern void glk_put_buffer_stream(StreamHandle streamId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len);
         [DllImport("libgarglk")]
         internal static extern void glk_put_buffer_uni([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] s, uint len);
         [DllImport("libgarglk")]
@@ -67,11 +67,11 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_set_window(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock);
+        internal static extern StreamHandle glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock);
+        internal static extern StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock);
         [DllImport("libgarglk")]
-        internal static extern void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode);
+        internal static extern void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode);
         [DllImport("libgarglk")]
         internal static extern void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val);
         [DllImport("libgarglk")]
@@ -87,7 +87,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_window_get_size(WindowHandle winId, out uint width, out uint height);
         [DllImport("libgarglk")]
-        internal static extern IntPtr glk_window_get_stream(WindowHandle winId);
+        internal static extern StreamHandle glk_window_get_stream(WindowHandle winId);
         [DllImport("libgarglk")]
         internal static extern void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos);
         [DllImport("libgarglk")]
@@ -112,7 +112,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
 
     class GarGlk: IGlk
     {
-        public BlorbError giblorb_set_resource_map(IntPtr fileStream) => Garglk_Pinvoke.giblorb_set_resource_map(fileStream);
+        public BlorbError giblorb_set_resource_map(StreamHandle fileStream) => Garglk_Pinvoke.giblorb_set_resource_map(fileStream);
         public void glk_cancel_hyperlink_event(WindowHandle winId) => Garglk_Pinvoke.glk_cancel_hyperlink_event(winId);
         public void glk_cancel_line_event(WindowHandle winId, ref Event ev) => Garglk_Pinvoke.glk_cancel_line_event(winId, ref ev);
         public void glk_exit() => Garglk_Pinvoke.glk_exit();
@@ -123,7 +123,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2) => Garglk_Pinvoke.glk_image_draw(winid, imageId, val1, val2);
         public uint glk_image_get_info(uint imageId, ref uint width, ref uint height) => Garglk_Pinvoke.glk_image_get_info(imageId, ref width, ref height);
         public void glk_put_buffer(byte[] s, uint len) => Garglk_Pinvoke.glk_put_buffer(s, len);
-        public void glk_put_buffer_stream(IntPtr streamId, byte[] s, uint len) => Garglk_Pinvoke.glk_put_buffer_stream(streamId, s, len);
+        public void glk_put_buffer_stream(StreamHandle streamId, byte[] s, uint len) => Garglk_Pinvoke.glk_put_buffer_stream(streamId, s, len);
         public void glk_put_buffer_uni(uint[] s, uint len) => Garglk_Pinvoke.glk_put_buffer_uni(s, len);
         public void glk_request_char_event(WindowHandle winId) => Garglk_Pinvoke.glk_request_char_event(winId);
         public void glk_request_hyperlink_event(WindowHandle winId) => Garglk_Pinvoke.glk_request_hyperlink_event(winId);
@@ -141,9 +141,9 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public void glk_set_hyperlink(uint linkval) => Garglk_Pinvoke.glk_set_hyperlink(linkval);
         public void glk_set_style(Style s) => Garglk_Pinvoke.glk_set_style(s);
         public void glk_set_window(WindowHandle winId) => Garglk_Pinvoke.glk_set_window(winId);
-        public IntPtr glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
-        public IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Garglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
-        public void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode) => Garglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
+        public StreamHandle glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock) => Garglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
+        public StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Garglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
+        public void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode) => Garglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
         public void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val) => Garglk_Pinvoke.glk_stylehint_set(wintype, styl, hint, val);
         public uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result) => Garglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);
         public void glk_tick() => Garglk_Pinvoke.glk_tick();
@@ -151,7 +151,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public void glk_window_close(WindowHandle winId, IntPtr streamResult) => Garglk_Pinvoke.glk_window_close(winId, streamResult);
         public void glk_window_flow_break(WindowHandle winId) => Garglk_Pinvoke.glk_window_flow_break(winId);
         public void glk_window_get_size(WindowHandle winId, out uint width, out uint height) => Garglk_Pinvoke.glk_window_get_size(winId, out width, out height);
-        public IntPtr glk_window_get_stream(WindowHandle winId) => Garglk_Pinvoke.glk_window_get_stream(winId);
+        public StreamHandle glk_window_get_stream(WindowHandle winId) => Garglk_Pinvoke.glk_window_get_stream(winId);
         public void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos) => Garglk_Pinvoke.glk_window_move_cursor(winId, xpos, ypos);
         public WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock) => Garglk_Pinvoke.glk_window_open(split, method, size, wintype, rock);
         public void garglk_set_zcolors(uint fg, uint bg) => Garglk_Pinvoke.garglk_set_zcolors(fg, bg);

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/Main.cs
@@ -81,7 +81,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         [DllImport("libgarglk")]
         internal static extern void glk_window_clear(WindowHandle winId);
         [DllImport("libgarglk")]
-        internal static extern void glk_window_close(WindowHandle winId, IntPtr streamResult);
+        internal static extern void glk_window_close(WindowHandle winId, ref StreamResult streamResult);
         [DllImport("libgarglk")]
         internal static extern void glk_window_flow_break(WindowHandle winId);
         [DllImport("libgarglk")]
@@ -148,7 +148,7 @@ namespace FrankenDrift.GlkRunner.Gargoyle
         public uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result) => Garglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);
         public void glk_tick() => Garglk_Pinvoke.glk_tick();
         public void glk_window_clear(WindowHandle winId) => Garglk_Pinvoke.glk_window_clear(winId);
-        public void glk_window_close(WindowHandle winId, IntPtr streamResult) => Garglk_Pinvoke.glk_window_close(winId, streamResult);
+        public void glk_window_close(WindowHandle winId, ref StreamResult streamResult) => Garglk_Pinvoke.glk_window_close(winId, ref streamResult);
         public void glk_window_flow_break(WindowHandle winId) => Garglk_Pinvoke.glk_window_flow_break(winId);
         public void glk_window_get_size(WindowHandle winId, out uint width, out uint height) => Garglk_Pinvoke.glk_window_get_size(winId, out width, out height);
         public StreamHandle glk_window_get_stream(WindowHandle winId) => Garglk_Pinvoke.glk_window_get_stream(winId);

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
@@ -16,13 +16,13 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_exit();
         [DllImport("Glk")]
-        internal static extern IntPtr glk_fileref_create_by_name(FileUsage usage, Glk.FileMode fmode, uint rock);
+        internal static extern FileRefHandle glk_fileref_create_by_name(FileUsage usage, [MarshalAs(UnmanagedType.LPStr)] string name, Glk.FileMode fmode, uint rock);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock);
+        internal static extern FileRefHandle glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_fileref_create_temp(FileUsage usage, uint rock);
+        internal static extern FileRefHandle glk_fileref_create_temp(FileUsage usage, uint rock);
         [DllImport("Glk")]
-        internal static extern void glk_fileref_destroy(IntPtr fref);
+        internal static extern void glk_fileref_destroy(FileRefHandle fref);
         [DllImport("Glk")]
         internal static extern uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2);
         [DllImport("Glk")]
@@ -66,7 +66,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_set_window(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_stream_open_file(IntPtr fileref, Glk.FileMode fmode, uint rock);
+        internal static extern IntPtr glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock);
         [DllImport("Glk")]
         internal static extern IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock);
         [DllImport("Glk")]
@@ -94,7 +94,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void garglk_set_zcolors(uint fg, uint bg);
         [DllImport("Glk")]
-        internal static extern IntPtr glkunix_fileref_get_name(IntPtr fileref);
+        internal static extern IntPtr glkunix_fileref_get_name(FileRefHandle fileref);
 
         [DllImport("Glk")]
         internal static extern int InitGlk(uint version);
@@ -109,10 +109,10 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public void glk_cancel_hyperlink_event(WindowHandle winId) => Winglk_Pinvoke.glk_cancel_hyperlink_event(winId);
         public void glk_cancel_line_event(WindowHandle winId, ref Event ev) => Winglk_Pinvoke.glk_cancel_line_event(winId, ref ev);
         public void glk_exit() => Winglk_Pinvoke.glk_exit();
-        public IntPtr glk_fileref_create_by_name(FileUsage usage, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_fileref_create_by_name(usage, fmode, rock);
-        public IntPtr glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_fileref_create_by_prompt(usage, fmode, rock);
-        public IntPtr glk_fileref_create_temp(FileUsage usage, uint rock) => Winglk_Pinvoke.glk_fileref_create_temp(usage, rock);
-        public void glk_fileref_destroy(IntPtr fref) => Winglk_Pinvoke.glk_fileref_destroy(fref);
+        public FileRefHandle glk_fileref_create_by_name(FileUsage usage, string name, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_fileref_create_by_name(usage, name, fmode, rock);
+        public FileRefHandle glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_fileref_create_by_prompt(usage, fmode, rock);
+        public FileRefHandle glk_fileref_create_temp(FileUsage usage, uint rock) => Winglk_Pinvoke.glk_fileref_create_temp(usage, rock);
+        public void glk_fileref_destroy(FileRefHandle fref) => Winglk_Pinvoke.glk_fileref_destroy(fref);
         public uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2) => Winglk_Pinvoke.glk_image_draw(winid, imageId, val1, val2);
         public uint glk_image_get_info(uint imageId, ref uint width, ref uint height) => Winglk_Pinvoke.glk_image_get_info(imageId, ref width, ref height);
         public void glk_put_buffer(byte[] s, uint len) => Winglk_Pinvoke.glk_put_buffer(s, len);
@@ -134,7 +134,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public void glk_set_hyperlink(uint linkval) => Winglk_Pinvoke.glk_set_hyperlink(linkval);
         public void glk_set_style(Style s) => Winglk_Pinvoke.glk_set_style(s);
         public void glk_set_window(WindowHandle winId) => Winglk_Pinvoke.glk_set_window(winId);
-        public IntPtr glk_stream_open_file(IntPtr fileref, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
+        public IntPtr glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
         public IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Winglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
         public void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode) => Winglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
         public void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val) => Winglk_Pinvoke.glk_stylehint_set(wintype, styl, hint, val);
@@ -148,7 +148,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos) => Winglk_Pinvoke.glk_window_move_cursor(winId, xpos, ypos);
         public WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock) => Winglk_Pinvoke.glk_window_open(split, method, size, wintype, rock);
         public void garglk_set_zcolors(uint fg, uint bg) => Winglk_Pinvoke.garglk_set_zcolors(fg, bg);
-        public string? glkunix_fileref_get_name(IntPtr fileref) => Marshal.PtrToStringAnsi(Winglk_Pinvoke.glkunix_fileref_get_name(fileref));
+        public string? glkunix_fileref_get_name(FileRefHandle fileref) => Marshal.PtrToStringAnsi(Winglk_Pinvoke.glkunix_fileref_get_name(fileref));
 
         public void SetGameName(string game) => Winglk_Pinvoke.winglk_window_set_title(game);
     }

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
@@ -80,7 +80,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_window_clear(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern void glk_window_close(WindowHandle winId, IntPtr streamResult);
+        internal static extern void glk_window_close(WindowHandle winId, ref StreamResult streamResult);
         [DllImport("Glk")]
         internal static extern void glk_window_flow_break(WindowHandle winId);
         [DllImport("Glk")]
@@ -141,7 +141,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result) => Winglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);
         public void glk_tick() => Winglk_Pinvoke.glk_tick();
         public void glk_window_clear(WindowHandle winId) => Winglk_Pinvoke.glk_window_clear(winId);
-        public void glk_window_close(WindowHandle winId, IntPtr streamResult) => Winglk_Pinvoke.glk_window_close(winId, streamResult);
+        public void glk_window_close(WindowHandle winId, ref StreamResult streamResult) => Winglk_Pinvoke.glk_window_close(winId, ref streamResult);
         public void glk_window_flow_break(WindowHandle winId) => Winglk_Pinvoke.glk_window_flow_break(winId);
         public void glk_window_get_size(WindowHandle winId, out uint width, out uint height) => Winglk_Pinvoke.glk_window_get_size(winId, out width, out height);
         public StreamHandle glk_window_get_stream(WindowHandle winId) => Winglk_Pinvoke.glk_window_get_stream(winId);

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
@@ -42,21 +42,21 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_schannel_create(uint rock);
+        internal static extern SoundChannel glk_schannel_create(uint rock);
         [DllImport("Glk")]
-        internal static extern void glk_schannel_destroy(IntPtr chan);
+        internal static extern void glk_schannel_destroy(SoundChannel chan);
         [DllImport("Glk")]
-        internal static extern void glk_schannel_pause(IntPtr chan);
+        internal static extern void glk_schannel_pause(SoundChannel chan);
         [DllImport("Glk")]
-        internal static extern uint glk_schannel_play(IntPtr chan, uint sndId);
+        internal static extern uint glk_schannel_play(SoundChannel chan, uint sndId);
         [DllImport("Glk")]
-        internal static extern uint glk_schannel_play_ext(IntPtr chan, uint sndId, uint repeats, uint notify);
+        internal static extern uint glk_schannel_play_ext(SoundChannel chan, uint sndId, uint repeats, uint notify);
         [DllImport("Glk")]
-        internal static extern void glk_schannel_set_volume(IntPtr chan, uint vol);
+        internal static extern void glk_schannel_set_volume(SoundChannel chan, uint vol);
         [DllImport("Glk")]
-        internal static extern void glk_schannel_stop(IntPtr chan);
+        internal static extern void glk_schannel_stop(SoundChannel chan);
         [DllImport("Glk")]
-        internal static extern void glk_schannel_unpause(IntPtr chan);
+        internal static extern void glk_schannel_unpause(SoundChannel chan);
         [DllImport("Glk")]
         internal static extern void glk_select(ref Event ev);
         [DllImport("Glk")]
@@ -122,14 +122,14 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public void glk_request_hyperlink_event(WindowHandle winId) => Winglk_Pinvoke.glk_request_hyperlink_event(winId);
         public unsafe void glk_request_line_event(WindowHandle win, byte* buf, uint maxlen, uint initlen) => Winglk_Pinvoke.glk_request_line_event(win, buf, maxlen, initlen);
         public unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen) => Winglk_Pinvoke.glk_request_line_event_uni(win, buf, maxlen, initlen);
-        public IntPtr glk_schannel_create(uint rock) => Winglk_Pinvoke.glk_schannel_create(rock);
-        public void glk_schannel_destroy(IntPtr chan) => Winglk_Pinvoke.glk_schannel_destroy(chan);
-        public void glk_schannel_pause(IntPtr chan) => Winglk_Pinvoke.glk_schannel_pause(chan);
-        public uint glk_schannel_play(IntPtr chan, uint sndId) => Winglk_Pinvoke.glk_schannel_play(chan, sndId);
-        public uint glk_schannel_play_ext(IntPtr chan, uint sndId, uint repeats, uint notify) => Winglk_Pinvoke.glk_schannel_play_ext(chan, sndId, repeats, notify);
-        public void glk_schannel_set_volume(IntPtr chan, uint vol) => Winglk_Pinvoke.glk_schannel_set_volume(chan, vol);
-        public void glk_schannel_stop(IntPtr chan) => Winglk_Pinvoke.glk_schannel_stop(chan);
-        public void glk_schannel_unpause(IntPtr chan) => Winglk_Pinvoke.glk_schannel_unpause(chan);
+        public SoundChannel glk_schannel_create(uint rock) => Winglk_Pinvoke.glk_schannel_create(rock);
+        public void glk_schannel_destroy(SoundChannel chan) => Winglk_Pinvoke.glk_schannel_destroy(chan);
+        public void glk_schannel_pause(SoundChannel chan) => Winglk_Pinvoke.glk_schannel_pause(chan);
+        public uint glk_schannel_play(SoundChannel chan, uint sndId) => Winglk_Pinvoke.glk_schannel_play(chan, sndId);
+        public uint glk_schannel_play_ext(SoundChannel chan, uint sndId, uint repeats, uint notify) => Winglk_Pinvoke.glk_schannel_play_ext(chan, sndId, repeats, notify);
+        public void glk_schannel_set_volume(SoundChannel chan, uint vol) => Winglk_Pinvoke.glk_schannel_set_volume(chan, vol);
+        public void glk_schannel_stop(SoundChannel chan) => Winglk_Pinvoke.glk_schannel_stop(chan);
+        public void glk_schannel_unpause(SoundChannel chan) => Winglk_Pinvoke.glk_schannel_unpause(chan);
         public void glk_select(ref Event ev) => Winglk_Pinvoke.glk_select(ref ev);
         public void glk_set_hyperlink(uint linkval) => Winglk_Pinvoke.glk_set_hyperlink(linkval);
         public void glk_set_style(Style s) => Winglk_Pinvoke.glk_set_style(s);

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
@@ -68,7 +68,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern StreamHandle glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock);
         [DllImport("Glk")]
-        internal static extern StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock);
+        internal static unsafe extern StreamHandle glk_stream_open_memory(byte* buf, uint buflen, Glk.FileMode mode, uint rock);
         [DllImport("Glk")]
         internal static extern void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode);
         [DllImport("Glk")]
@@ -135,7 +135,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public void glk_set_style(Style s) => Winglk_Pinvoke.glk_set_style(s);
         public void glk_set_window(WindowHandle winId) => Winglk_Pinvoke.glk_set_window(winId);
         public StreamHandle glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
-        public StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Winglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
+        public unsafe StreamHandle glk_stream_open_memory(byte* buf, uint buflen, Glk.FileMode mode, uint rock) => Winglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
         public void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode) => Winglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
         public void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val) => Winglk_Pinvoke.glk_stylehint_set(wintype, styl, hint, val);
         public uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result) => Winglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
@@ -10,9 +10,9 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern BlorbError giblorb_set_resource_map(IntPtr fileStream);
         [DllImport("Glk")]
-        internal static extern void glk_cancel_hyperlink_event(IntPtr winId);
+        internal static extern void glk_cancel_hyperlink_event(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern void glk_cancel_line_event(IntPtr winId, ref Event ev);
+        internal static extern void glk_cancel_line_event(WindowHandle winId, ref Event ev);
         [DllImport("Glk")]
         internal static extern void glk_exit();
         [DllImport("Glk")]
@@ -24,7 +24,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_fileref_destroy(IntPtr fref);
         [DllImport("Glk")]
-        internal static extern uint glk_image_draw(IntPtr winid, uint imageId, int val1, int val2);
+        internal static extern uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2);
         [DllImport("Glk")]
         internal static extern uint glk_image_get_info(uint imageId, ref uint width, ref uint height);
         [DllImport("Glk")]
@@ -34,13 +34,13 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_put_buffer_uni([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] s, uint len);
         [DllImport("Glk")]
-        internal static extern void glk_request_char_event(IntPtr winId);
+        internal static extern void glk_request_char_event(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern void glk_request_hyperlink_event(IntPtr winId);
+        internal static extern void glk_request_hyperlink_event(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern unsafe void glk_request_line_event(IntPtr win, byte* buf, uint maxlen, uint initlen);
+        internal static extern unsafe void glk_request_line_event(WindowHandle win, byte* buf, uint maxlen, uint initlen);
         [DllImport("Glk")]
-        internal static extern unsafe void glk_request_line_event_uni(IntPtr win, uint* buf, uint maxlen, uint initlen);
+        internal static extern unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen);
         [DllImport("Glk")]
         internal static extern IntPtr glk_schannel_create(uint rock);
         [DllImport("Glk")]
@@ -64,7 +64,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_set_style(Style s);
         [DllImport("Glk")]
-        internal static extern void glk_set_window(IntPtr winId);
+        internal static extern void glk_set_window(WindowHandle winId);
         [DllImport("Glk")]
         internal static extern IntPtr glk_stream_open_file(IntPtr fileref, Glk.FileMode fmode, uint rock);
         [DllImport("Glk")]
@@ -74,23 +74,23 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val);
         [DllImport("Glk")]
-        internal static extern uint glk_style_measure(IntPtr winid, Style styl, StyleHint hint, ref uint result);
+        internal static extern uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result);
         [DllImport("Glk")]
         internal static extern void glk_tick();
         [DllImport("Glk")]
-        internal static extern void glk_window_clear(IntPtr winId);
+        internal static extern void glk_window_clear(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern void glk_window_close(IntPtr winId, IntPtr streamResult);
+        internal static extern void glk_window_close(WindowHandle winId, IntPtr streamResult);
         [DllImport("Glk")]
-        internal static extern void glk_window_flow_break(IntPtr winId);
+        internal static extern void glk_window_flow_break(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern void glk_window_get_size(IntPtr winId, out uint width, out uint height);
+        internal static extern void glk_window_get_size(WindowHandle winId, out uint width, out uint height);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_window_get_stream(IntPtr winId);
+        internal static extern IntPtr glk_window_get_stream(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern void glk_window_move_cursor(IntPtr winId, uint xpos, uint ypos);
+        internal static extern void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_window_open(IntPtr split, WinMethod method, uint size, WinType wintype, uint rock);
+        internal static extern WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock);
         [DllImport("Glk")]
         internal static extern void garglk_set_zcolors(uint fg, uint bg);
         [DllImport("Glk")]
@@ -106,22 +106,22 @@ namespace FrankenDrift.GlkRunner.WinGlk
     class WindowsGlk : IGlk
     {
         public BlorbError giblorb_set_resource_map(IntPtr fileStream) => Winglk_Pinvoke.giblorb_set_resource_map(fileStream);
-        public void glk_cancel_hyperlink_event(IntPtr winId) => Winglk_Pinvoke.glk_cancel_hyperlink_event(winId);
-        public void glk_cancel_line_event(IntPtr winId, ref Event ev) => Winglk_Pinvoke.glk_cancel_line_event(winId, ref ev);
+        public void glk_cancel_hyperlink_event(WindowHandle winId) => Winglk_Pinvoke.glk_cancel_hyperlink_event(winId);
+        public void glk_cancel_line_event(WindowHandle winId, ref Event ev) => Winglk_Pinvoke.glk_cancel_line_event(winId, ref ev);
         public void glk_exit() => Winglk_Pinvoke.glk_exit();
         public IntPtr glk_fileref_create_by_name(FileUsage usage, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_fileref_create_by_name(usage, fmode, rock);
         public IntPtr glk_fileref_create_by_prompt(FileUsage usage, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_fileref_create_by_prompt(usage, fmode, rock);
         public IntPtr glk_fileref_create_temp(FileUsage usage, uint rock) => Winglk_Pinvoke.glk_fileref_create_temp(usage, rock);
         public void glk_fileref_destroy(IntPtr fref) => Winglk_Pinvoke.glk_fileref_destroy(fref);
-        public uint glk_image_draw(IntPtr winid, uint imageId, int val1, int val2) => Winglk_Pinvoke.glk_image_draw(winid, imageId, val1, val2);
+        public uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2) => Winglk_Pinvoke.glk_image_draw(winid, imageId, val1, val2);
         public uint glk_image_get_info(uint imageId, ref uint width, ref uint height) => Winglk_Pinvoke.glk_image_get_info(imageId, ref width, ref height);
-        public void glk_put_buffer([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len) => Winglk_Pinvoke.glk_put_buffer(s, len);
-        public void glk_put_buffer_stream(IntPtr streamId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len) => Winglk_Pinvoke.glk_put_buffer_stream(streamId, s, len);
-        public void glk_put_buffer_uni([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] s, uint len) => Winglk_Pinvoke.glk_put_buffer_uni(s, len);
-        public void glk_request_char_event(IntPtr winId) => Winglk_Pinvoke.glk_request_char_event(winId);
-        public void glk_request_hyperlink_event(IntPtr winId) => Winglk_Pinvoke.glk_request_hyperlink_event(winId);
-        public unsafe void glk_request_line_event(IntPtr win, byte* buf, uint maxlen, uint initlen) => Winglk_Pinvoke.glk_request_line_event(win, buf, maxlen, initlen);
-        public unsafe void glk_request_line_event_uni(IntPtr win, uint* buf, uint maxlen, uint initlen) => Winglk_Pinvoke.glk_request_line_event_uni(win, buf, maxlen, initlen);
+        public void glk_put_buffer(byte[] s, uint len) => Winglk_Pinvoke.glk_put_buffer(s, len);
+        public void glk_put_buffer_stream(IntPtr streamId, byte[] s, uint len) => Winglk_Pinvoke.glk_put_buffer_stream(streamId, s, len);
+        public void glk_put_buffer_uni(uint[] s, uint len) => Winglk_Pinvoke.glk_put_buffer_uni(s, len);
+        public void glk_request_char_event(WindowHandle winId) => Winglk_Pinvoke.glk_request_char_event(winId);
+        public void glk_request_hyperlink_event(WindowHandle winId) => Winglk_Pinvoke.glk_request_hyperlink_event(winId);
+        public unsafe void glk_request_line_event(WindowHandle win, byte* buf, uint maxlen, uint initlen) => Winglk_Pinvoke.glk_request_line_event(win, buf, maxlen, initlen);
+        public unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen) => Winglk_Pinvoke.glk_request_line_event_uni(win, buf, maxlen, initlen);
         public IntPtr glk_schannel_create(uint rock) => Winglk_Pinvoke.glk_schannel_create(rock);
         public void glk_schannel_destroy(IntPtr chan) => Winglk_Pinvoke.glk_schannel_destroy(chan);
         public void glk_schannel_pause(IntPtr chan) => Winglk_Pinvoke.glk_schannel_pause(chan);
@@ -133,20 +133,20 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public void glk_select(ref Event ev) => Winglk_Pinvoke.glk_select(ref ev);
         public void glk_set_hyperlink(uint linkval) => Winglk_Pinvoke.glk_set_hyperlink(linkval);
         public void glk_set_style(Style s) => Winglk_Pinvoke.glk_set_style(s);
-        public void glk_set_window(IntPtr winId) => Winglk_Pinvoke.glk_set_window(winId);
+        public void glk_set_window(WindowHandle winId) => Winglk_Pinvoke.glk_set_window(winId);
         public IntPtr glk_stream_open_file(IntPtr fileref, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
         public IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Winglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
         public void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode) => Winglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
         public void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val) => Winglk_Pinvoke.glk_stylehint_set(wintype, styl, hint, val);
-        public uint glk_style_measure(IntPtr winid, Style styl, StyleHint hint, ref uint result) => Winglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);
+        public uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result) => Winglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);
         public void glk_tick() => Winglk_Pinvoke.glk_tick();
-        public void glk_window_clear(IntPtr winId) => Winglk_Pinvoke.glk_window_clear(winId);
-        public void glk_window_close(IntPtr winId, IntPtr streamResult) => Winglk_Pinvoke.glk_window_close(winId, streamResult);
-        public void glk_window_flow_break(IntPtr winId) => Winglk_Pinvoke.glk_window_flow_break(winId);
-        public void glk_window_get_size(IntPtr winId, out uint width, out uint height) => Winglk_Pinvoke.glk_window_get_size(winId, out width, out height);
-        public IntPtr glk_window_get_stream(IntPtr winId) => Winglk_Pinvoke.glk_window_get_stream(winId);
-        public void glk_window_move_cursor(IntPtr winId, uint xpos, uint ypos) => Winglk_Pinvoke.glk_window_move_cursor(winId, xpos, ypos);
-        public IntPtr glk_window_open(IntPtr split, WinMethod method, uint size, WinType wintype, uint rock) => Winglk_Pinvoke.glk_window_open(split, method, size, wintype, rock);
+        public void glk_window_clear(WindowHandle winId) => Winglk_Pinvoke.glk_window_clear(winId);
+        public void glk_window_close(WindowHandle winId, IntPtr streamResult) => Winglk_Pinvoke.glk_window_close(winId, streamResult);
+        public void glk_window_flow_break(WindowHandle winId) => Winglk_Pinvoke.glk_window_flow_break(winId);
+        public void glk_window_get_size(WindowHandle winId, out uint width, out uint height) => Winglk_Pinvoke.glk_window_get_size(winId, out width, out height);
+        public IntPtr glk_window_get_stream(WindowHandle winId) => Winglk_Pinvoke.glk_window_get_stream(winId);
+        public void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos) => Winglk_Pinvoke.glk_window_move_cursor(winId, xpos, ypos);
+        public WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock) => Winglk_Pinvoke.glk_window_open(split, method, size, wintype, rock);
         public void garglk_set_zcolors(uint fg, uint bg) => Winglk_Pinvoke.garglk_set_zcolors(fg, bg);
         public string? glkunix_fileref_get_name(IntPtr fileref) => Marshal.PtrToStringAnsi(Winglk_Pinvoke.glkunix_fileref_get_name(fileref));
 

--- a/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
+++ b/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.WinGlk/Main.cs
@@ -8,7 +8,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
     {
         // Universal Glk functions.
         [DllImport("Glk")]
-        internal static extern BlorbError giblorb_set_resource_map(IntPtr fileStream);
+        internal static extern BlorbError giblorb_set_resource_map(StreamHandle fileStream);
         [DllImport("Glk")]
         internal static extern void glk_cancel_hyperlink_event(WindowHandle winId);
         [DllImport("Glk")]
@@ -30,7 +30,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_put_buffer([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len);
         [DllImport("Glk")]
-        internal static extern void glk_put_buffer_stream(IntPtr streamId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len);
+        internal static extern void glk_put_buffer_stream(StreamHandle streamId, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1)] byte[] s, uint len);
         [DllImport("Glk")]
         internal static extern void glk_put_buffer_uni([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] s, uint len);
         [DllImport("Glk")]
@@ -66,11 +66,11 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_set_window(WindowHandle winId);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock);
+        internal static extern StreamHandle glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock);
+        internal static extern StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock);
         [DllImport("Glk")]
-        internal static extern void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode);
+        internal static extern void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode);
         [DllImport("Glk")]
         internal static extern void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val);
         [DllImport("Glk")]
@@ -86,7 +86,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         [DllImport("Glk")]
         internal static extern void glk_window_get_size(WindowHandle winId, out uint width, out uint height);
         [DllImport("Glk")]
-        internal static extern IntPtr glk_window_get_stream(WindowHandle winId);
+        internal static extern StreamHandle glk_window_get_stream(WindowHandle winId);
         [DllImport("Glk")]
         internal static extern void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos);
         [DllImport("Glk")]
@@ -105,7 +105,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
     }
     class WindowsGlk : IGlk
     {
-        public BlorbError giblorb_set_resource_map(IntPtr fileStream) => Winglk_Pinvoke.giblorb_set_resource_map(fileStream);
+        public BlorbError giblorb_set_resource_map(StreamHandle fileStream) => Winglk_Pinvoke.giblorb_set_resource_map(fileStream);
         public void glk_cancel_hyperlink_event(WindowHandle winId) => Winglk_Pinvoke.glk_cancel_hyperlink_event(winId);
         public void glk_cancel_line_event(WindowHandle winId, ref Event ev) => Winglk_Pinvoke.glk_cancel_line_event(winId, ref ev);
         public void glk_exit() => Winglk_Pinvoke.glk_exit();
@@ -116,7 +116,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2) => Winglk_Pinvoke.glk_image_draw(winid, imageId, val1, val2);
         public uint glk_image_get_info(uint imageId, ref uint width, ref uint height) => Winglk_Pinvoke.glk_image_get_info(imageId, ref width, ref height);
         public void glk_put_buffer(byte[] s, uint len) => Winglk_Pinvoke.glk_put_buffer(s, len);
-        public void glk_put_buffer_stream(IntPtr streamId, byte[] s, uint len) => Winglk_Pinvoke.glk_put_buffer_stream(streamId, s, len);
+        public void glk_put_buffer_stream(StreamHandle streamId, byte[] s, uint len) => Winglk_Pinvoke.glk_put_buffer_stream(streamId, s, len);
         public void glk_put_buffer_uni(uint[] s, uint len) => Winglk_Pinvoke.glk_put_buffer_uni(s, len);
         public void glk_request_char_event(WindowHandle winId) => Winglk_Pinvoke.glk_request_char_event(winId);
         public void glk_request_hyperlink_event(WindowHandle winId) => Winglk_Pinvoke.glk_request_hyperlink_event(winId);
@@ -134,9 +134,9 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public void glk_set_hyperlink(uint linkval) => Winglk_Pinvoke.glk_set_hyperlink(linkval);
         public void glk_set_style(Style s) => Winglk_Pinvoke.glk_set_style(s);
         public void glk_set_window(WindowHandle winId) => Winglk_Pinvoke.glk_set_window(winId);
-        public IntPtr glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
-        public IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Winglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
-        public void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode) => Winglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
+        public StreamHandle glk_stream_open_file(FileRefHandle fileref, Glk.FileMode fmode, uint rock) => Winglk_Pinvoke.glk_stream_open_file(fileref, fmode, rock);
+        public StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, Glk.FileMode mode, uint rock) => Winglk_Pinvoke.glk_stream_open_memory(buf, buflen, mode, rock);
+        public void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode) => Winglk_Pinvoke.glk_stream_set_position(stream, pos, seekMode);
         public void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val) => Winglk_Pinvoke.glk_stylehint_set(wintype, styl, hint, val);
         public uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result) => Winglk_Pinvoke.glk_style_measure(winid, styl, hint, ref result);
         public void glk_tick() => Winglk_Pinvoke.glk_tick();
@@ -144,7 +144,7 @@ namespace FrankenDrift.GlkRunner.WinGlk
         public void glk_window_close(WindowHandle winId, IntPtr streamResult) => Winglk_Pinvoke.glk_window_close(winId, streamResult);
         public void glk_window_flow_break(WindowHandle winId) => Winglk_Pinvoke.glk_window_flow_break(winId);
         public void glk_window_get_size(WindowHandle winId, out uint width, out uint height) => Winglk_Pinvoke.glk_window_get_size(winId, out width, out height);
-        public IntPtr glk_window_get_stream(WindowHandle winId) => Winglk_Pinvoke.glk_window_get_stream(winId);
+        public StreamHandle glk_window_get_stream(WindowHandle winId) => Winglk_Pinvoke.glk_window_get_stream(winId);
         public void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos) => Winglk_Pinvoke.glk_window_move_cursor(winId, xpos, ypos);
         public WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock) => Winglk_Pinvoke.glk_window_open(split, method, size, wintype, rock);
         public void garglk_set_zcolors(uint fg, uint bg) => Winglk_Pinvoke.garglk_set_zcolors(fg, bg);

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
@@ -199,10 +199,9 @@ namespace FrankenDrift.GlkRunner.Glk
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct FileRefHandle
+    public record struct FileRefHandle(IntPtr hfref)
     {
-        private IntPtr hfref;
-        void IsValid() { hfref = IntPtr.Zero; }
+        internal bool IsValid => hfref != IntPtr.Zero;
     }
 
     public interface IGlk
@@ -212,10 +211,10 @@ namespace FrankenDrift.GlkRunner.Glk
         void glk_cancel_hyperlink_event(WindowHandle winId);
         void glk_cancel_line_event(WindowHandle winId, ref Event ev);
         void glk_exit();
-        IntPtr glk_fileref_create_by_name(FileUsage usage, FileMode fmode, uint rock);
-        IntPtr glk_fileref_create_by_prompt(FileUsage usage, FileMode fmode, uint rock);
-        IntPtr glk_fileref_create_temp(FileUsage usage, uint rock);
-        void glk_fileref_destroy(IntPtr fref);
+        FileRefHandle glk_fileref_create_by_name(FileUsage usage, string name, FileMode fmode, uint rock);
+        FileRefHandle glk_fileref_create_by_prompt(FileUsage usage, FileMode fmode, uint rock);
+        FileRefHandle glk_fileref_create_temp(FileUsage usage, uint rock);
+        void glk_fileref_destroy(FileRefHandle fref);
         uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2);
         uint glk_image_get_info(uint imageId, ref uint width, ref uint height);
         void glk_put_buffer(byte[] s, uint len);
@@ -237,7 +236,7 @@ namespace FrankenDrift.GlkRunner.Glk
         void glk_set_hyperlink(uint linkval);
         void glk_set_style(Style s);
         void glk_set_window(WindowHandle winId);
-        IntPtr glk_stream_open_file(IntPtr fileref, FileMode fmode, uint rock);
+        IntPtr glk_stream_open_file(FileRefHandle fileref, FileMode fmode, uint rock);
         IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, FileMode mode, uint rock);
         void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode);
         void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val);
@@ -251,7 +250,7 @@ namespace FrankenDrift.GlkRunner.Glk
         void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos);
         WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock);
         void garglk_set_zcolors(uint fg, uint bg);
-        string? glkunix_fileref_get_name(IntPtr fileref);
+        string? glkunix_fileref_get_name(FileRefHandle fileref);
 
         // And some extra functions we want that could have different implementations
         void SetGameName(string game);

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
@@ -257,7 +257,7 @@ namespace FrankenDrift.GlkRunner.Glk
         void glk_set_style(Style s);
         void glk_set_window(WindowHandle winId);
         StreamHandle glk_stream_open_file(FileRefHandle fileref, FileMode fmode, uint rock);
-        StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, FileMode mode, uint rock);
+        unsafe StreamHandle glk_stream_open_memory(byte* buf, uint buflen, FileMode mode, uint rock);
         void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode);
         void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val);
         uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result);

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
@@ -193,6 +193,13 @@ namespace FrankenDrift.GlkRunner.Glk
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    public readonly struct StreamResult
+    {
+        public readonly uint readcount;
+        public readonly uint writecount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     public record struct WindowHandle(IntPtr hwnd)
     {
         internal bool IsValid => hwnd != IntPtr.Zero;
@@ -215,6 +222,7 @@ namespace FrankenDrift.GlkRunner.Glk
     {
         internal bool IsValid => schan != IntPtr.Zero;
     }
+
 
     public interface IGlk
     {
@@ -255,7 +263,7 @@ namespace FrankenDrift.GlkRunner.Glk
         uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result);
         void glk_tick();
         void glk_window_clear(WindowHandle winId);
-        void glk_window_close(WindowHandle winId, IntPtr streamResult);
+        void glk_window_close(WindowHandle winId, ref StreamResult streamResult);
         void glk_window_flow_break(WindowHandle winId);
         void glk_window_get_size(WindowHandle winId, out uint width, out uint height);
         StreamHandle glk_window_get_stream(WindowHandle winId);

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
@@ -204,10 +204,16 @@ namespace FrankenDrift.GlkRunner.Glk
         internal bool IsValid => hfref != IntPtr.Zero;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public record struct StreamHandle(IntPtr hstrm)
+    {
+        internal bool IsValid => hstrm != IntPtr.Zero;
+    }
+
     public interface IGlk
     {
 #pragma warning disable IDE1006 // Naming Styles
-        BlorbError giblorb_set_resource_map(IntPtr fileStream);
+        BlorbError giblorb_set_resource_map(StreamHandle fileStream);
         void glk_cancel_hyperlink_event(WindowHandle winId);
         void glk_cancel_line_event(WindowHandle winId, ref Event ev);
         void glk_exit();
@@ -218,7 +224,7 @@ namespace FrankenDrift.GlkRunner.Glk
         uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2);
         uint glk_image_get_info(uint imageId, ref uint width, ref uint height);
         void glk_put_buffer(byte[] s, uint len);
-        void glk_put_buffer_stream(IntPtr streamId, byte[] s, uint len);
+        void glk_put_buffer_stream(StreamHandle streamId, byte[] s, uint len);
         void glk_put_buffer_uni(uint[] s, uint len);
         void glk_request_char_event(WindowHandle winId);
         void glk_request_hyperlink_event(WindowHandle winId);
@@ -236,9 +242,9 @@ namespace FrankenDrift.GlkRunner.Glk
         void glk_set_hyperlink(uint linkval);
         void glk_set_style(Style s);
         void glk_set_window(WindowHandle winId);
-        IntPtr glk_stream_open_file(FileRefHandle fileref, FileMode fmode, uint rock);
-        IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, FileMode mode, uint rock);
-        void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode);
+        StreamHandle glk_stream_open_file(FileRefHandle fileref, FileMode fmode, uint rock);
+        StreamHandle glk_stream_open_memory(IntPtr buf, uint buflen, FileMode mode, uint rock);
+        void glk_stream_set_position(StreamHandle stream, int pos, SeekMode seekMode);
         void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val);
         uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result);
         void glk_tick();
@@ -246,7 +252,7 @@ namespace FrankenDrift.GlkRunner.Glk
         void glk_window_close(WindowHandle winId, IntPtr streamResult);
         void glk_window_flow_break(WindowHandle winId);
         void glk_window_get_size(WindowHandle winId, out uint width, out uint height);
-        IntPtr glk_window_get_stream(WindowHandle winId);
+        StreamHandle glk_window_get_stream(WindowHandle winId);
         void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos);
         WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock);
         void garglk_set_zcolors(uint fg, uint bg);

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Data.Common;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace FrankenDrift.GlkRunner
@@ -181,34 +183,48 @@ namespace FrankenDrift.GlkRunner.Glk
         Default = 0xffffffff
     }
 
+    [StructLayout(LayoutKind.Sequential)]
     public struct Event
     {
         internal EventType type;
-        internal IntPtr win_handle;
+        internal WindowHandle win_handle;
         internal uint val1;
         internal uint val2;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public record struct WindowHandle(IntPtr hwnd)
+    {
+        internal bool IsValid => hwnd != IntPtr.Zero;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct FileRefHandle
+    {
+        private IntPtr hfref;
+        void IsValid() { hfref = IntPtr.Zero; }
     }
 
     public interface IGlk
     {
 #pragma warning disable IDE1006 // Naming Styles
         BlorbError giblorb_set_resource_map(IntPtr fileStream);
-        void glk_cancel_hyperlink_event(IntPtr winId);
-        void glk_cancel_line_event(IntPtr winId, ref Event ev);
+        void glk_cancel_hyperlink_event(WindowHandle winId);
+        void glk_cancel_line_event(WindowHandle winId, ref Event ev);
         void glk_exit();
         IntPtr glk_fileref_create_by_name(FileUsage usage, FileMode fmode, uint rock);
         IntPtr glk_fileref_create_by_prompt(FileUsage usage, FileMode fmode, uint rock);
         IntPtr glk_fileref_create_temp(FileUsage usage, uint rock);
         void glk_fileref_destroy(IntPtr fref);
-        uint glk_image_draw(IntPtr winid, uint imageId, int val1, int val2);
+        uint glk_image_draw(WindowHandle winid, uint imageId, int val1, int val2);
         uint glk_image_get_info(uint imageId, ref uint width, ref uint height);
         void glk_put_buffer(byte[] s, uint len);
         void glk_put_buffer_stream(IntPtr streamId, byte[] s, uint len);
         void glk_put_buffer_uni(uint[] s, uint len);
-        void glk_request_char_event(IntPtr winId);
-        void glk_request_hyperlink_event(IntPtr winId);
-        unsafe void glk_request_line_event(IntPtr win, byte* buf, uint maxlen, uint initlen);
-        unsafe void glk_request_line_event_uni(IntPtr win, uint* buf, uint maxlen, uint initlen);
+        void glk_request_char_event(WindowHandle winId);
+        void glk_request_hyperlink_event(WindowHandle winId);
+        unsafe void glk_request_line_event(WindowHandle win, byte* buf, uint maxlen, uint initlen);
+        unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen);
         IntPtr glk_schannel_create(uint rock);
         void glk_schannel_destroy(IntPtr chan);
         void glk_schannel_pause(IntPtr chan);
@@ -220,20 +236,20 @@ namespace FrankenDrift.GlkRunner.Glk
         void glk_select(ref Event ev);
         void glk_set_hyperlink(uint linkval);
         void glk_set_style(Style s);
-        void glk_set_window(IntPtr winId);
+        void glk_set_window(WindowHandle winId);
         IntPtr glk_stream_open_file(IntPtr fileref, FileMode fmode, uint rock);
         IntPtr glk_stream_open_memory(IntPtr buf, uint buflen, FileMode mode, uint rock);
         void glk_stream_set_position(IntPtr stream, int pos, SeekMode seekMode);
         void glk_stylehint_set(WinType wintype, Style styl, StyleHint hint, int val);
-        uint glk_style_measure(IntPtr winid, Style styl, StyleHint hint, ref uint result);
+        uint glk_style_measure(WindowHandle winid, Style styl, StyleHint hint, ref uint result);
         void glk_tick();
-        void glk_window_clear(IntPtr winId);
-        void glk_window_close(IntPtr winId, IntPtr streamResult);
-        void glk_window_flow_break(IntPtr winId);
-        void glk_window_get_size(IntPtr winId, out uint width, out uint height);
-        IntPtr glk_window_get_stream(IntPtr winId);
-        void glk_window_move_cursor(IntPtr winId, uint xpos, uint ypos);
-        IntPtr glk_window_open(IntPtr split, WinMethod method, uint size, WinType wintype, uint rock);
+        void glk_window_clear(WindowHandle winId);
+        void glk_window_close(WindowHandle winId, IntPtr streamResult);
+        void glk_window_flow_break(WindowHandle winId);
+        void glk_window_get_size(WindowHandle winId, out uint width, out uint height);
+        IntPtr glk_window_get_stream(WindowHandle winId);
+        void glk_window_move_cursor(WindowHandle winId, uint xpos, uint ypos);
+        WindowHandle glk_window_open(WindowHandle split, WinMethod method, uint size, WinType wintype, uint rock);
         void garglk_set_zcolors(uint fg, uint bg);
         string? glkunix_fileref_get_name(IntPtr fileref);
 

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkApi.cs
@@ -210,6 +210,12 @@ namespace FrankenDrift.GlkRunner.Glk
         internal bool IsValid => hstrm != IntPtr.Zero;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public record struct SoundChannel(IntPtr schan)
+    {
+        internal bool IsValid => schan != IntPtr.Zero;
+    }
+
     public interface IGlk
     {
 #pragma warning disable IDE1006 // Naming Styles
@@ -230,14 +236,14 @@ namespace FrankenDrift.GlkRunner.Glk
         void glk_request_hyperlink_event(WindowHandle winId);
         unsafe void glk_request_line_event(WindowHandle win, byte* buf, uint maxlen, uint initlen);
         unsafe void glk_request_line_event_uni(WindowHandle win, uint* buf, uint maxlen, uint initlen);
-        IntPtr glk_schannel_create(uint rock);
-        void glk_schannel_destroy(IntPtr chan);
-        void glk_schannel_pause(IntPtr chan);
-        uint glk_schannel_play(IntPtr chan, uint sndId);
-        uint glk_schannel_play_ext(IntPtr chan, uint sndId, uint repeats, uint notify);
-        void glk_schannel_set_volume(IntPtr chan, uint vol);
-        void glk_schannel_stop(IntPtr chan);
-        void glk_schannel_unpause(IntPtr chan);
+        SoundChannel glk_schannel_create(uint rock);
+        void glk_schannel_destroy(SoundChannel chan);
+        void glk_schannel_pause(SoundChannel chan);
+        uint glk_schannel_play(SoundChannel chan, uint sndId);
+        uint glk_schannel_play_ext(SoundChannel chan, uint sndId, uint repeats, uint notify);
+        void glk_schannel_set_volume(SoundChannel chan, uint vol);
+        void glk_schannel_stop(SoundChannel chan);
+        void glk_schannel_unpause(SoundChannel chan);
         void glk_select(ref Event ev);
         void glk_set_hyperlink(uint linkval);
         void glk_set_style(Style s);

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkGridWin.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkGridWin.cs
@@ -6,9 +6,9 @@ namespace FrankenDrift.GlkRunner
     {
         private IGlk GlkApi;
         private GlkUtil GlkUtil;
-        private IntPtr glkwin_handle;
+        private WindowHandle glkwin_handle;
 
-        internal GlkGridWin(IGlk glk, IntPtr handle)
+        internal GlkGridWin(IGlk glk, WindowHandle handle)
         {
             GlkApi = glk;
             GlkUtil = new GlkUtil(GlkApi);

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkHtmlWin.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkHtmlWin.cs
@@ -507,7 +507,10 @@ namespace FrankenDrift.GlkRunner
 
                 // TODO: Nicht verwaltete Ressourcen (nicht verwaltete Objekte) freigeben und Finalizer überschreiben
                 // TODO: Große Felder auf NULL setzen
-                GlkApi.glk_window_close(glkwin_handle, IntPtr.Zero);
+
+                // we're not interested in the result, but alas...
+                StreamResult r = new();
+                GlkApi.glk_window_close(glkwin_handle, ref r);
                 glkwin_handle = new(IntPtr.Zero);
             }
         }

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkHtmlWin.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkHtmlWin.cs
@@ -64,7 +64,7 @@ namespace FrankenDrift.GlkRunner
             "TADS-monospace"
         };
 
-        internal IntPtr Stream => GlkApi.glk_window_get_stream(glkwin_handle);
+        internal StreamHandle Stream => GlkApi.glk_window_get_stream(glkwin_handle);
 
         internal GlkHtmlWin(IGlk glk)
         {

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkSession.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkSession.cs
@@ -19,7 +19,7 @@ namespace FrankenDrift.GlkRunner
         public bool Locked => false;
         public void Close() => GlkApi.glk_exit();
 
-        private readonly Dictionary<int, IntPtr> _sndChannels = new();
+        private readonly Dictionary<int, SoundChannel> _sndChannels = new();
         private readonly Dictionary<int, string> _recentlyPlayedSounds = new();
 
         public MainSession(string gameFile, IGlk glk)

--- a/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkSession.cs
+++ b/FrankenDrift.GlkRunner/Frankendrift.GlkRunner/GlkSession.cs
@@ -137,7 +137,7 @@ namespace FrankenDrift.GlkRunner
         public string QueryRestorePath()
         {
             var fileref = GlkApi.glk_fileref_create_by_prompt(FileUsage.SavedGame | FileUsage.BinaryMode, Glk.FileMode.Read, 0);
-            if (fileref == IntPtr.Zero) return "";
+            if (!fileref.IsValid) return "";
             var result = GlkApi.glkunix_fileref_get_name(fileref);
             GlkApi.glk_fileref_destroy(fileref);
             return result;
@@ -151,7 +151,7 @@ namespace FrankenDrift.GlkRunner
         public string QuerySavePath()
         {
             var fileref = GlkApi.glk_fileref_create_by_prompt(FileUsage.SavedGame | FileUsage.BinaryMode, Glk.FileMode.Write, 0);
-            if (fileref == IntPtr.Zero) return "";
+            if (!fileref.IsValid) return "";
             var result = GlkApi.glkunix_fileref_get_name(fileref);
             GlkApi.glk_fileref_destroy(fileref);
             return result;


### PR DESCRIPTION
Use structs to represent Glk opaque types, rather than using `IntPtr` everywhere.

Part of #38.

(@curiousdannii I'd formally request a review but GitHub is being dense again.)